### PR TITLE
add gene_id as backup name attribute

### DIFF
--- a/svpack
+++ b/svpack
@@ -272,7 +272,11 @@ class Gff:
             self.phase = gff_line.phase
             self.attributes = gff_line.attributes
             self.id = self.attributes["ID"].split(":")[1]
-            self.symbol = self.attributes["Name"]
+            try:
+                self.symbol = self.attributes["Name"]
+            except KeyError:
+                self.symbol = self.attributes["gene_id"]
+
             self.transcripts = []
 
         def add_transcript(self, gff_transcript):


### PR DESCRIPTION
with this gff: http://ftp.ensembl.org/pub/current_gff3/homo_sapiens/Homo_sapiens.GRCh38.104.gff3.gz

Many features with `gene` as the feature_type do not have a `Name` attribute and therefore the parser fails. This uses `gene_id` in case `Name` is not found.