### PR TITLE
calculate svlen for BND

### DIFF
--- a/svpack
+++ b/svpack
@@ -4,6 +4,7 @@ import argparse
 heapq=None
 collections=None
 pysam=None
+math=None
 sys=None
 
 def get_svlen_abs(v):
@@ -14,6 +15,12 @@ def get_svlen_abs(v):
     # Calculate SVLEN from REF and ALT alleles for INS and DEL when ALT is not a symbolic allele
     elif "SVTYPE" in v.info and v.info["SVTYPE"] in ("INS","DEL") and "<" not in v.alts[0]:
         return abs(len(v.alts[0])-len(v.ref))
+    # Return MATEDIST for BNDs if available
+    if "SVTYPE" in v.info and v.info["SVTYPE"]=="BND" and "MATEDIST" in v.info:
+        return int(v.info["MATEDIST"])
+    # Return +inf for BNDs without MATEDIST
+    elif "SVTYPE" in v.info and v.info["SVTYPE"]=="BND":
+        return math.inf
     # Calculate SVLEN from END INFO field when available
     elif v.stop > v.start:
         return abs(v.stop - v.start)
@@ -521,6 +528,7 @@ def main():
     global sys; import sys
     global collections; import collections
     global heapq; import heapq
+    global math; import math
 
     if hasattr(args, "func"):
         args.func(args)


### PR DESCRIPTION
Solves the problem in #9.  If MATEDIST is available (i.e., BNDs are on same chromosome) set SVLEN to MATEDIST.  Otherwise, set to `math.inf`.